### PR TITLE
feat(client): implement remaining registry support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -67,8 +67,8 @@ pub struct ClientError(ClientErrorImpl<WireError>);
 /// A read-only reference to the current contents of the registry.
 ///
 /// This reference holds a lock on the registry that prevents updates while
-/// the reference exists. If you have two subseqently obtained `RegistryRef`
-/// values the contents of the regististy may have changed between obtaining
+/// the reference exists. If you have two consecutively obtained `RegistryRef`
+/// values the contents of the registry may have changed between obtaining
 /// those references.
 #[derive(Debug)]
 pub struct RegistryRef<'a> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -291,8 +291,8 @@ impl RegistryRef<'_> {
     pub fn iter(&self) -> impl Iterator<Item = RegistryItem> {
         self.guard.iter().map(|(name, global)| RegistryItem {
             name: *name,
-            interface: global.interface.as_ref(),
-            version: global.version,
+            interface: global.interface(),
+            version: global.version(),
         })
         // todo!();
         // #[allow(unreachable_code)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -738,20 +738,20 @@ mod tests {
 
     #[tokio::test]
     async fn display_impl_registry_contains_added_globals() {
-        use protocols::{Events::Wayland, wayland::wl_registry::GlobalEvent};
+        use protocols::{wayland::wl_registry::GlobalEvent, Events::Wayland};
         let (display, mut send) = new_dispatch_display_impl().await;
         let interface = CString::new("wl_compositor").expect("Can't create interface name");
         let do_send = async {
-            send.send(Ok(Wayland(GlobalEvent::new(new_object_id(2),1, interface, 1).into()))).await.expect("Couldn't send GlobalEvent");
+            send.send(Ok(Wayland(
+                GlobalEvent::new(new_object_id(2), 1, interface, 1).into(),
+            )))
+            .await
+            .expect("Couldn't send GlobalEvent");
             send.close_channel();
         };
 
-
         let sut = Arc::new(display);
-        let (_, result) = tokio::join!(
-            do_send,
-            sut.clone().dispatch()
-        );
+        let (_, result) = tokio::join!(do_send, sut.clone().dispatch());
         result.expect("Dispatch returned an error");
 
         assert_eq!(sut.registry().iter().count(), 1);

--- a/src/client.rs
+++ b/src/client.rs
@@ -357,7 +357,7 @@ impl RegistryRef<'_> {
 }
 
 impl RegistryItem<'_> {
-    /// Get the numberic name of the item.
+    /// Get the numeric name of the item.
     pub fn name(&self) -> GlobalName {
         GlobalName(self.name)
     }
@@ -374,7 +374,7 @@ impl RegistryItem<'_> {
 }
 
 impl RegistryAddItem {
-    /// Get the numberic name of the item.
+    /// Get the numeric name of the item.
     pub fn name(&self) -> GlobalName {
         GlobalName(self.name)
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -154,8 +154,6 @@ impl fmt::Display for ClientPhase {
 // === impl inner Display (DisplayImpl) ===
 
 struct DisplayImpl<Si, St, WS, E> {
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     registry: Registry,
     callbacks: Callbacks,
     recv: AtomicCell<Option<St>>,
@@ -294,9 +292,6 @@ impl RegistryRef<'_> {
             interface: global.interface(),
             version: global.version(),
         })
-        // todo!();
-        // #[allow(unreachable_code)]
-        // std::iter::empty()
     }
 }
 

--- a/src/core/codec.rs
+++ b/src/core/codec.rs
@@ -62,6 +62,7 @@ use super::{
 /// clients and events for servers.
 ///
 /// [Wayland]: https://wayland.freedesktop.org/
+#[derive(Debug)]
 pub(crate) struct WaylandCodec<R, P> {
     decode_state: DecodeState,
     _marker: PhantomData<(R, P)>,
@@ -163,7 +164,7 @@ impl<R, P> Default for WaylandCodec<R, P> {
 
 // === WaylandHeader ===
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 struct WaylandHeader {
     sender: u32,
 
@@ -232,6 +233,7 @@ where
 
 // === DecodeState ===
 
+#[derive(Debug)]
 enum DecodeState {
     Head,
     Args(WaylandHeader),

--- a/src/core/role.rs
+++ b/src/core/role.rs
@@ -15,9 +15,11 @@ use super::{FromOpcodeError, MessageMaker, OpCode, ProtocolFamily, ProtocolFamil
 /// clients.
 pub trait Role {}
 
+#[derive(Debug)]
 pub(crate) struct ServerRole {}
 impl Role for ServerRole {}
 
+#[derive(Debug)]
 pub(crate) struct ClientRole {}
 impl Role for ClientRole {}
 

--- a/src/core/transport.rs
+++ b/src/core/transport.rs
@@ -94,6 +94,7 @@ use super::{
 /// [`AsyncRead`]: tokio::io::AsyncRead
 /// [`AsyncWrite`]: tokio::io::AsyncWrite
 #[pin_project]
+#[derive(Debug)]
 pub struct WaylandTransport<T, R, P, M> {
     #[pin]
     inner: Framed<T, WaylandCodec<R, P>>,

--- a/src/core/wire.rs
+++ b/src/core/wire.rs
@@ -11,7 +11,7 @@
 //! [Wayland]: https://wayland.freedesktop.org/
 
 use std::{
-    fmt::Display,
+    fmt::{self, Display},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -46,6 +46,7 @@ pub(crate) type WireProtocol<T, R, PF> = (WireSend<T, R, PF>, WireRecv<T, R, PF>
 pub(crate) fn make_wire_protocol<T, R, PF>(channel: T) -> WireProtocol<T, R, PF>
 where
     PF: ProtocolFamily + HasFd<R> + SendMsg<R>,
+    <PF as SendMsg<R>>::Output: fmt::Debug,
     R: Role,
     T: IoChannel + Unpin,
     Extractor: ExtractIndex<R>,
@@ -131,6 +132,7 @@ impl Display for SendIoErrorPhase {
 }
 
 /// The concrete implementation of [WaylandState] for the wire protocol.
+#[derive(Debug)]
 pub(crate) struct WireState<R, PF> {
     map: ObjectMap<PF, R>,
 }
@@ -163,9 +165,11 @@ where
 ///
 /// [Wayland]: https://wayland.freedesktop.org/
 #[pin_project]
+#[derive(Debug)]
 pub(crate) struct WireSend<T, R, PF>
 where
     PF: SendMsg<R>,
+    <PF as SendMsg<R>>::Output: fmt::Debug,
     R: Role,
 {
     #[pin]
@@ -175,6 +179,7 @@ where
 impl<T, R, PF> Sink<SendMsgType<R, PF>> for WireSend<T, R, PF>
 where
     PF: ProtocolFamily + SendMsg<R>,
+    <PF as SendMsg<R>>::Output: fmt::Debug,
     R: Role,
     T: IoChannel + Unpin,
 {
@@ -219,6 +224,7 @@ where
 ///
 /// [Wayland]: https://wayland.freedesktop.org/
 #[pin_project]
+#[derive(Debug)]
 pub(crate) struct WireRecv<T, R, PF> {
     #[pin]
     inner: SplitStream<Transport<T, R, PF>>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -104,8 +104,9 @@ impl Registry {
 
     /// Return a [`Stream`] of [`GlobalChange`] notifications.
     ///
-    /// The supplied [`CancellationToken`] will be cancel if the caller can't keep up with the
-    /// generated steam of change notifications. This is a somewhat brutal form of back pressure.
+    /// The supplied [`CancellationToken`] will be cancelled if the caller
+    /// can't keep up with the generated steam of change notifications. This
+    /// is a somewhat brutal form of back pressure.
     // TODO: remove this when it is no longer needed
     #[allow(dead_code)]
     pub fn changes(&self, cancel: CancellationToken) -> impl Stream<Item = GlobalChange> {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -105,8 +105,6 @@ impl Registry {
     /// The supplied [`CancellationToken`] will be cancelled if the caller
     /// can't keep up with the generated steam of change notifications. This
     /// is a somewhat brutal form of back pressure.
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     pub fn changes(&self, cancel: CancellationToken) -> impl Stream<Item = GlobalChange> {
         let mut state = self.shared.state.write().unwrap();
 
@@ -233,8 +231,6 @@ impl<'a> Index<&u32> for RegistryLockRef<'a> {
 }
 
 impl<'a> RegistryLockRef<'a> {
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     pub fn iter(&self) -> impl Iterator<Item = GlobalKvRef> {
         self.lock.map.iter()
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -25,7 +25,7 @@
 use std::{
     collections::HashMap,
     convert::TryInto,
-    ffi::CString,
+    ffi::{CStr, CString},
     iter::FromIterator,
     ops::Index,
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
@@ -40,8 +40,8 @@ use tokio_util::sync::CancellationToken;
 /// [Wayland]: https://wayland.freedesktop.org/
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Global {
-    pub(crate) interface: CString,
-    pub(crate) version: u32,
+    interface: CString,
+    version: u32,
 }
 
 pub(crate) type GlobalKv = (u32, Global);
@@ -251,10 +251,16 @@ impl<'a> RegistryLockRef<'a> {
 }
 
 impl Global {
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     pub fn new(interface: CString, version: u32) -> Self {
         Self { interface, version }
+    }
+
+    pub(crate) fn interface(&self) -> &CStr {
+        &self.interface
+    }
+
+    pub(crate) fn version(&self) -> u32 {
+        self.version
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -45,8 +45,6 @@ pub(crate) struct Global {
 }
 
 pub(crate) type GlobalKv = (u32, Global);
-// TODO: remove this when it is no longer needed
-#[allow(dead_code)]
 pub(crate) type GlobalKvRef<'a> = (&'a u32, &'a Global);
 
 /// A change indicator for the [`Registry`] from which the change notification arises.
@@ -122,16 +120,12 @@ impl Registry {
         reciever
     }
 
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     pub fn lock_mut(&self) -> RegistryLockMut {
         RegistryLockMut {
             lock: self.shared.state.write().unwrap(),
         }
     }
 
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     pub fn lock_ref(&self) -> RegistryLockRef {
         RegistryLockRef {
             lock: self.shared.state.read().unwrap(),
@@ -194,8 +188,6 @@ impl Default for State {
 }
 
 impl<'a> RegistryLockMut<'a> {
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     pub fn add(&mut self, key: u32, value: Global) {
         self.lock.map.insert(key, value.clone());
         self.publish(GlobalChange::Add(key, value));
@@ -210,8 +202,6 @@ impl<'a> RegistryLockMut<'a> {
         key
     }
 
-    // TODO: remove this when it is no longer needed
-    #[allow(dead_code)]
     pub fn remove(&mut self, key: u32) {
         self.lock.map.remove(&key);
         self.publish(GlobalChange::Remove(key));

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -40,8 +40,8 @@ use tokio_util::sync::CancellationToken;
 /// [Wayland]: https://wayland.freedesktop.org/
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Global {
-    interface: CString,
-    version: u32,
+    pub(crate) interface: CString,
+    pub(crate) version: u32,
 }
 
 pub(crate) type GlobalKv = (u32, Global);
@@ -244,7 +244,7 @@ impl<'a> Index<&u32> for RegistryLockRef<'a> {
 impl<'a> RegistryLockRef<'a> {
     // TODO: remove this when it is no longer needed
     #[allow(dead_code)]
-    pub fn iter(&self) -> impl Iterator<Item=GlobalKvRef> {
+    pub fn iter(&self) -> impl Iterator<Item = GlobalKvRef> {
         self.lock.map.iter()
     }
 }
@@ -281,9 +281,16 @@ mod tests {
 
         let sut = Registry::new();
         let key = sut.lock_mut().add_new(global.clone());
-        let results: Vec<_> = sut.lock_ref().iter().map(|(name, global)| (*name, global.clone())).collect();
+        let results: Vec<_> = sut
+            .lock_ref()
+            .iter()
+            .map(|(name, global)| (*name, global.clone()))
+            .collect();
 
-        assert!(results.contains(&(key, global)), "Expected global not in the iteration.");
+        assert!(
+            results.contains(&(key, global)),
+            "Expected global not in the iteration."
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implement methods on Display to iterate the current contents of the
registry and to receive notifications of changes to the registry

Add handlers for the wl_registry events that occur after the initial
handshake to keep the local Registry updated and to provide the change
notifications.

The implementation of the change notficiations includes the possiblity
of Display::dispatch() being cancelled if the notification are not
handled fast enough to keep up. This is a form of backpressure but
there may be more elegant forms of backpressure.

Closes: #4
